### PR TITLE
Use simple python script entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,28 @@
-# Conex
+# Spray Connect (sc)
 
-Conex is a lightweight CLI that tries several connection methods (SSH, Telnet
-and console) until one succeeds.
+Spray Connect is a lightweight CLI that tries several connection methods (SSH,
+Telnet and console) until one succeeds.
 
-## Install from GitHub
+## Quick start
 
-The package is not published on PyPI yet. Install it directly from GitHub:
-
-```bash
-pip install git+https://github.com/yourusername/conex.git
-```
-
-This installs the `conex` command and its dependencies.
-
-### Run without installing
-
-Alternatively, clone the repository and execute the CLI with Python:
+Clone the repository and run the script directly with Python:
 
 ```bash
-git clone https://github.com/yourusername/conex.git
-cd conex
-python -m conex.cli <hostname> [--config path/to/hosts.yaml]
+git clone https://github.com/adamspera/spray-connect.git
+cd spray-connect
+python3 sc.py <hostname> --config path/to/hosts.yaml
 ```
 
 ## Usage
 
-Once installed (or when running via Python), call the CLI with a hostname:
+Run the CLI with a hostname:
 
 ```bash
-conex <hostname> [--config path/to/hosts.yaml]
+python3 sc.py <hostname> --config path/to/hosts.yaml
 ```
 
-The configuration is loaded from `~/.conex/hosts.yaml` by default or from the
-path set in the `CONEX_HOSTS_FILE` environment variable.
+The configuration is loaded from `~/.sc/hosts.yaml` by default or from the path
+set in the `SC_HOSTS_FILE` environment variable.
 
 ### Configuration file format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "conex"
+name = "spray-connect"
 version = "0.1.0"
 description = "CLI tool to connect to devices using SSH/Telnet with fallback"
 authors = [{name="Auto Generated"}]
@@ -17,4 +17,4 @@ dependencies = [
 ]
 
 [project.scripts]
-conex = "conex.cli:main"
+sc = "sc.cli:main"

--- a/sc.py
+++ b/sc.py
@@ -1,0 +1,5 @@
+from sc.cli import main
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/sc/__init__.py
+++ b/sc/__init__.py
@@ -1,2 +1,2 @@
-"""Conex package."""
+"""Spray Connect package."""
 __all__ = ["cli", "connection_manager", "logger"]

--- a/sc/cli.py
+++ b/sc/cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 
 from .connection_manager import ConnectionManager, load_config
-from .logger import logger
+from .logger import logger, console
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -12,13 +12,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("hostname", help="Hostname to connect to")
     parser.add_argument(
         "--config",
-        help="Path to hosts YAML file (default: ~/.conex/hosts.yaml or CONEX_HOSTS_FILE)",
+        help="Path to hosts YAML file (default: ~/.sc/hosts.yaml or SC_HOSTS_FILE)",
     )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    console.print()  # spacing
     try:
         config = load_config(args.config)
     except FileNotFoundError:
@@ -29,9 +30,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         method = manager.connect(args.hostname)
         logger.info(f"Successfully connected using {method}")
+        console.print()
         return 0
     except Exception as exc:  # catch all connection errors
         logger.error(str(exc))
+        console.print()
         return 1
 
 

--- a/sc/connection_manager.py
+++ b/sc/connection_manager.py
@@ -13,8 +13,8 @@ except ImportError:  # pragma: no cover - paramiko missing during tests
 
 import telnetlib
 
-DEFAULT_CONFIG_PATH = os.path.expanduser("~/.conex/hosts.yaml")
-ENV_CONFIG = "CONEX_HOSTS_FILE"
+DEFAULT_CONFIG_PATH = os.path.expanduser("~/.sc/hosts.yaml")
+ENV_CONFIG = "SC_HOSTS_FILE"
 
 
 def load_config(path: Optional[str] = None) -> Dict[str, Any]:

--- a/sc/logger.py
+++ b/sc/logger.py
@@ -6,7 +6,11 @@ console = Console()
 # Configure loguru to use rich for formatting
 logger.remove()
 
-LOG_FORMAT = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <level>{message}</level>"
+LOG_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green>  "
+    "<level>{level:<8}</level>  "
+    "<level>{message}</level>"
+)
 logger.add(lambda msg: console.print(msg, end=""), colorize=True, format=LOG_FORMAT)
 
 __all__ = ["logger", "console"]


### PR DESCRIPTION
## Summary
- add a small `sc.py` so the tool can be run with `python3 sc.py`
- simplify README instructions to use the script and point to the new repo
- rename code base from **Conex** to **Spray Connect** (sc)

## Testing
- `pytest -q`
- `python3 sc.py hostname1 --config test_hosts.yaml` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68566b9afdfc832a9f351e92e5e04f01